### PR TITLE
Parser: fix reading it->extra on big endian when bytesNeeded == 1

### DIFF
--- a/src/cborparser.c
+++ b/src/cborparser.c
@@ -203,10 +203,13 @@ static CborError preparse_value(CborValue *it)
         it->extra = 0;
 
         /* read up to 16 bits into it->extra */
-        if (bytesNeeded <= 2) {
+        if (bytesNeeded == 1) {
+            uint8_t extra;
+            read_bytes_unchecked(it, &extra, 1, bytesNeeded);
+            it->extra = extra;
+        } else if (bytesNeeded == 2) {
             read_bytes_unchecked(it, &it->extra, 1, bytesNeeded);
-            if (bytesNeeded == 2)
-                it->extra = cbor_ntohs(it->extra);
+            it->extra = cbor_ntohs(it->extra);
         } else {
             cbor_static_assert(CborIteratorFlag_IntegerValueTooLarge == (Value32Bit & 3));
             cbor_static_assert((CborIteratorFlag_IntegerValueIs64Bit |


### PR DESCRIPTION
`&it->extra` points to the wrong byte of uint16_t on big endian systems.

By using a temporary one-byte value we ensure that the code works fine on both big and little endian systems.

Results of running tests in `tests/parser/` on s390x before this fix:

    Totals: 2037 passed, 293 failed, 0 skipped, 0 blacklisted, 221ms

After this fix:

    Totals: 2330 passed, 0 failed, 0 skipped, 0 blacklisted, 254ms